### PR TITLE
GitHub Actions: use ccacche

### DIFF
--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -54,11 +54,17 @@ jobs:
     - name: install ccache
       run: sudo apt install ccache
 
+    - name: Get timestamp
+      run: echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
+      id: get_timestamp
+
     - name: Cache
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}/.ccache
-        key: ccache-${{ runner.os }}-${{ matrix.arch }}
+        key: ccache-${{ runner.os }}-${{ matrix.arch }}-${{ steps.get_timestamp.outputs.timestamp }}
+        restore-keys: |
+          ccache-${{ runner.os }}-${{ matrix.arch }}-
 
     - name: Configure CMake
       shell: bash
@@ -430,11 +436,17 @@ jobs:
       - name: Install ccache
         run: brew install ccache
 
+      - name: Get timestamp
+        run: echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
+        id: get_timestamp
+
       - name: Setup Cache
         uses: actions/cache@v2
         with:
           path: ${{runner.workspace}}/.ccache
           key: ccache-${{ runner.os }}
+          restore-keys: |
+            ccache-${{ runner.os }}-
 
       - name: Configure CMake
         shell: bash

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -26,13 +26,6 @@ jobs:
 
     name: Linux Build (${{ matrix.bits }} bit / ${{ matrix.arch }})
 
-    env:
-      CCACHE_BASEDIR: ${{runner.workspace}}
-      CCACHE_DIR: ${{runner.workspace}}/.ccache
-      CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 6
-      CCACHE_MAXSIZE: 500M
-
     steps:
     - uses: actions/checkout@v2
       with:
@@ -78,6 +71,12 @@ jobs:
         LDFLAGS: -m${{ matrix.bits }}
         CXXFLAGS: -m${{ matrix.bits }}
 
+        CCACHE_BASEDIR: ${{runner.workspace}}
+        CCACHE_DIR: ${{runner.workspace}}/.ccache
+        CCACHE_COMPRESS: true
+        CCACHE_COMPRESSLEVEL: 6
+        CCACHE_MAXSIZE: 500M
+
 #    - name: get info
 #      run: |
 #        gcc --version
@@ -88,6 +87,12 @@ jobs:
       working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release${{ matrix.bits }}
       shell: bash
       run: cmake --build . --target BrickSim BrickSimTests --config $BUILD_TYPE -j $(nproc --all)
+      env:
+        CCACHE_BASEDIR: ${{runner.workspace}}
+        CCACHE_DIR: ${{runner.workspace}}/.ccache
+        CCACHE_COMPRESS: true
+        CCACHE_COMPRESSLEVEL: 6
+        CCACHE_MAXSIZE: 500M
 
     - if: "contains(github.event.head_commit.message, 'codeql')"
       name: Perform CodeQL Analysis
@@ -407,13 +412,6 @@ jobs:
 
     name: MacOS Build
 
-    env:
-      CCACHE_BASEDIR: ${{runner.workspace}}
-      CCACHE_DIR: ${{runner.workspace}}/.ccache
-      CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 6
-      CCACHE_MAXSIZE: 500M
-
     steps:
       - uses: actions/checkout@v2
         with:
@@ -443,6 +441,12 @@ jobs:
           CC: clang
           CXX: clang++
 
+          CCACHE_BASEDIR: ${{runner.workspace}}
+          CCACHE_DIR: ${{runner.workspace}}/.ccache
+          CCACHE_COMPRESS: true
+          CCACHE_COMPRESSLEVEL: 6
+          CCACHE_MAXSIZE: 500M
+
       - name: get info
         run: |
           gcc --version
@@ -453,6 +457,12 @@ jobs:
         working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release
         shell: bash
         run: cmake --build . --target BrickSim --config $BUILD_TYPE -j $(nproc --all)
+        env:
+          CCACHE_BASEDIR: ${{runner.workspace}}
+          CCACHE_DIR: ${{runner.workspace}}/.ccache
+          CCACHE_COMPRESS: true
+          CCACHE_COMPRESSLEVEL: 6
+          CCACHE_MAXSIZE: 500M
 
       - name: Upload Binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -269,16 +269,38 @@ jobs:
       - name: Setup workspace
         run: ./setup_workspace.sh only${{ matrix.bits }}bit
 
+      - name: Install ccache
+        run: pacman -S mingw-w64-${{ matrix.arch }}-ccache --noconfirm --needed
+
+      - name: Get timestamp
+        run: echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
+        id: get_timestamp
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        with:
+          path: ${{runner.workspace}}/.ccache
+          key: ccache-${{ runner.os }}-${{ matrix.arch }}-${{ steps.get_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ccache-${{ runner.os }}-${{ matrix.arch }}-
+
       - name: Build
         env:
           CC: /C/msys64/mingw${{ matrix.bits }}/bin/gcc.exe
           CXX: /C/msys64/mingw${{ matrix.bits }}/bin/g++.exe
+
+          CCACHE_BASEDIR: ${{runner.workspace}}
+          CCACHE_DIR: ${{runner.workspace}}/.ccache
+          CCACHE_COMPRESS: true
+          CCACHE_COMPRESSLEVEL: 6
+          CCACHE_MAXSIZE: 500M
         run: |
           mkdir -p cmake-build/release${{ matrix.bits }}
           cd cmake-build/release${{ matrix.bits }}
           cmake -G "MSYS Makefiles" ../.. -DCMAKE_PREFIX_PATH=/C/mingw64 -DCMAKE_MAKE_PROGRAM=/C/msys64/usr/bin/make.exe \
             -DGIT_COMMIT_HASH:STRING=$(./scripts/get_git_commit_hash.sh) -DGIT_COMMIT_COUNT:STRING=$(../../scripts/get_git_commit_count.sh) \
-            -DTOTAL_HOURS:STRING=$(../../scripts/get_git_total_hours.sh) -DGIT_VERSION_TAG:STRING=$(../../scripts/get_git_tag.sh)
+            -DTOTAL_HOURS:STRING=$(../../scripts/get_git_total_hours.sh) -DGIT_VERSION_TAG:STRING=$(../../scripts/get_git_tag.sh) \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
           cmake --build . --target BrickSim BrickSimTests --config Release  -j $(nproc --all)
       - if: always()
         run: |

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - stable
-      - multiplatform_unittests
+      - gha_add_ccache
     paths-ignore:
       - "docs/**"
       - '**/*.md'
@@ -25,6 +25,13 @@ jobs:
         ]
 
     name: Linux Build (${{ matrix.bits }} bit / ${{ matrix.arch }})
+
+    env:
+      CCACHE_BASEDIR: ${{runner.workspace}}
+      CCACHE_DIR: ${{runner.workspace}}/.ccache
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_MAXSIZE: 500M
 
     steps:
     - uses: actions/checkout@v2
@@ -51,10 +58,19 @@ jobs:
     - run: ls -l /usr/lib | grep linux
     - run: ls -l /usr
 
+    - name: install ccache
+      run: sudo apt install ccache
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: ${{runner.workspace}}/.ccache
+        key: ccache-${{ runner.os }}-${{ matrix.arch }}
+
     - name: Configure CMake
       shell: bash
       working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release${{ matrix.bits }}
-      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_LIBRARY_PATH=/usr/lib/${{ matrix.arch }}-linux-gnu -G Ninja
+      run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_LIBRARY_PATH=/usr/lib/${{ matrix.arch }}-linux-gnu -G Ninja
       env:
         CC: gcc-10
         CXX: g++-10
@@ -391,6 +407,13 @@ jobs:
 
     name: MacOS Build
 
+    env:
+      CCACHE_BASEDIR: ${{runner.workspace}}
+      CCACHE_DIR: ${{runner.workspace}}/.ccache
+      CCACHE_COMPRESS: true
+      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_MAXSIZE: 500M
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -403,10 +426,19 @@ jobs:
       - name: Create Build Environment
         run: mkdir -p $GITHUB_WORKSPACE/cmake-build/release
 
+      - name: Install ccache
+        run: brew install ccache
+
+      - name: Setup Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{runner.workspace}}/.ccache
+          key: ccache-${{ runner.os }}
+
       - name: Configure CMake
         shell: bash
         working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja
         env:
           CC: clang
           CXX: clang++

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -86,13 +86,18 @@ jobs:
     - name: Build
       working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release${{ matrix.bits }}
       shell: bash
-      run: cmake --build . --target BrickSim BrickSimTests --config $BUILD_TYPE -j $(nproc --all)
+      run: |
+        ccache -z # zero statistics
+        cmake --build . --target BrickSim BrickSimTests --config $BUILD_TYPE -j $(nproc --all)
       env:
         CCACHE_BASEDIR: ${{runner.workspace}}
         CCACHE_DIR: ${{runner.workspace}}/.ccache
         CCACHE_COMPRESS: true
         CCACHE_COMPRESSLEVEL: 6
         CCACHE_MAXSIZE: 500M
+
+    - name: Print ccache statistics
+      run: ccache -s
 
     - if: "contains(github.event.head_commit.message, 'codeql')"
       name: Perform CodeQL Analysis
@@ -456,13 +461,18 @@ jobs:
       - name: Build
         working-directory: ${{runner.workspace}}/BrickSim/cmake-build/release
         shell: bash
-        run: cmake --build . --target BrickSim --config $BUILD_TYPE -j $(nproc --all)
+        run: |
+          ccache -z # zero statistics
+          cmake --build . --target BrickSim --config $BUILD_TYPE -j $(nproc --all)
         env:
           CCACHE_BASEDIR: ${{runner.workspace}}
           CCACHE_DIR: ${{runner.workspace}}/.ccache
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 6
           CCACHE_MAXSIZE: 500M
+
+      - name: Print ccache statistics
+        run: ccache -s
 
       - name: Upload Binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
       - stable
-      - gha_add_ccache
+      - gha_use_ccacche
     paths-ignore:
       - "docs/**"
       - '**/*.md'

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -89,15 +89,13 @@ jobs:
       run: |
         ccache -z # zero statistics
         cmake --build . --target BrickSim BrickSimTests --config $BUILD_TYPE -j $(nproc --all)
+        ccache -s # print statistics
       env:
         CCACHE_BASEDIR: ${{runner.workspace}}
         CCACHE_DIR: ${{runner.workspace}}/.ccache
         CCACHE_COMPRESS: true
         CCACHE_COMPRESSLEVEL: 6
         CCACHE_MAXSIZE: 500M
-
-    - name: Print ccache statistics
-      run: ccache -s
 
     - if: "contains(github.event.head_commit.message, 'codeql')"
       name: Perform CodeQL Analysis
@@ -464,15 +462,13 @@ jobs:
         run: |
           ccache -z # zero statistics
           cmake --build . --target BrickSim --config $BUILD_TYPE -j $(nproc --all)
+          ccache -s # print statistics
         env:
           CCACHE_BASEDIR: ${{runner.workspace}}
           CCACHE_DIR: ${{runner.workspace}}/.ccache
           CCACHE_COMPRESS: true
           CCACHE_COMPRESSLEVEL: 6
           CCACHE_MAXSIZE: 500M
-
-      - name: Print ccache statistics
-        run: ccache -s
 
       - name: Upload Binary
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -301,7 +301,9 @@ jobs:
             -DGIT_COMMIT_HASH:STRING=$(./scripts/get_git_commit_hash.sh) -DGIT_COMMIT_COUNT:STRING=$(../../scripts/get_git_commit_count.sh) \
             -DTOTAL_HOURS:STRING=$(../../scripts/get_git_total_hours.sh) -DGIT_VERSION_TAG:STRING=$(../../scripts/get_git_tag.sh) \
             -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
+          ccache -z # zero statistics
           cmake --build . --target BrickSim BrickSimTests --config Release  -j $(nproc --all)
+          ccache -s # print statistics
       - if: always()
         run: |
           cd cmake-build/release${{ matrix.bits }}

--- a/.github/workflows/cmake_build.yml
+++ b/.github/workflows/cmake_build.yml
@@ -58,7 +58,7 @@ jobs:
       run: echo "::set-output name=timestamp::$(date --iso-8601=seconds)"
       id: get_timestamp
 
-    - name: Cache
+    - name: Setup cache
       uses: actions/cache@v2
       with:
         path: ${{runner.workspace}}/.ccache

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,5 +3,6 @@ namespace controller {
 }
 
 int main() {
+    static_assert(false, "just to test ccache");
     return controller::run();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,5 @@ namespace controller {
 }
 
 int main() {
-    static_assert(false, "just to test ccache");
     return controller::run();
 }


### PR DESCRIPTION
Was able to save between 2 and 3 minutes per build by using `ccache` and [actions/cache](https://github.com/actions/cache)